### PR TITLE
Install kernel update files into trustmeimage

### DIFF
--- a/classes/trustmex86.bbclass
+++ b/classes/trustmex86.bbclass
@@ -18,13 +18,10 @@ TRUSTME_IMAGE="${TRUSTME_IMAGE_OUT}/trustmeimage.img"
 
 TRUSTME_DEFAULTCONFIG="trustx-core.conf"
 
-do_image_trustmex86[depends] += " \
+do_uefi_bootpart[depends] += " \
     sbsigntool-native:do_populate_sysroot \
+    ${TRUSTME_GENERIC_DEPENDS} \
 "
-
-
-do_image_trustmex86[depends] += " ${TRUSTME_GENERIC_DEPENDS} "
-
 
 do_uefi_bootpart () {
 	rm -fr ${TRUSTME_BOOTPART_DIR}
@@ -67,9 +64,8 @@ do_uefi_bootpart () {
 
 IMAGE_CMD_trustmex86 () {
 	bbnote  "Using standard trustme partition"
-	do_uefi_bootpart
 	do_build_trustmeimage
 }
 
-#addtask do_uefi_bootpart before IMAGE_CMD_trustmex86
+addtask do_uefi_bootpart before IMAGE_CMD_trustmex86
 #addtask do_build_trustmeimage after do_uefi_bootpart

--- a/images/trustx-cml.bbappend
+++ b/images/trustx-cml.bbappend
@@ -3,7 +3,7 @@ inherit trustmex86
 ##### provide a tarball for cml update
 include images/trustx-signing.inc
 deltask do_sign_guestos
-addtask do_sign_guestos before do_image
+addtask do_sign_guestos after do_uefi_bootpart before do_image_trustmex86
 
 GUESTS_OUT = "${DEPLOY_DIR_IMAGE}/cml_updates"
 CLEAN_GUEST_OUT = ""

--- a/images/trustx-cml.bbappend
+++ b/images/trustx-cml.bbappend
@@ -2,11 +2,14 @@ inherit trustmex86
 
 ##### provide a tarball for cml update
 include images/trustx-signing.inc
+deltask do_sign_guestos
+addtask do_sign_guestos before do_image
 
 GUESTS_OUT = "${DEPLOY_DIR_IMAGE}/cml_updates"
 CLEAN_GUEST_OUT = ""
 OS_NAME = "kernel"
 UPDATE_OUT="${GUESTS_OUT}/${OS_NAME}-${TRUSTME_VERSION}"
+UPDATE_FILES="${UPDATE_OUT} ${UPDATE_OUT}.conf ${UPDATE_OUT}.sig ${UPDATE_OUT}.cert"
 
 do_sign_guestos_prepend () {
 	mkdir -p "${UPDATE_OUT}"


### PR DESCRIPTION
Copying the kernel files introduced a cyclic dependency between
do_image and do_sign_guestos. Therefore the task order was changed
for trustx-cml. It is now:

- for trustx-core: do_image -> do_sign_guestos
- for trustx-cml: do_sign_guestos -> do_image

See also: https://github.com/gyroidos/meta-trustx/pull/160#issue-1296233090