### PR TITLE
SecureBoot Keytool for trustme-installer

### DIFF
--- a/images/trustx-installer-initramfs.bb
+++ b/images/trustx-installer-initramfs.bb
@@ -30,6 +30,7 @@ PACKAGE_INSTALL = "\
 	parted \
 	util-linux-sfdisk \
 	dosfstools \
+	installer-keytool \
 "
 
 IMAGE_LINUGUAS = " "

--- a/recipes-kernel/efitools/efitools-common.inc
+++ b/recipes-kernel/efitools/efitools-common.inc
@@ -1,0 +1,12 @@
+SUMMARY = "efitools"
+DESCRIPTION = "EFI tools to generate an deploy platform keys"
+HOMEPAGE = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git/"
+SECTION = "console/tools"
+LICENSE = "GPLv2"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=e28f66b16cb46be47b20a4cdfe6e99a1"
+
+SRC_URI = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git/snapshot/efitools_${PV}.tar.gz"
+SRC_URI += "file://0001-lib-console-compatibly-fix-to-upstream-change-of-gnu.patch"
+
+S = "${WORKDIR}/efitools_${PV}"

--- a/recipes-kernel/efitools/efitools-native_%.bbappend
+++ b/recipes-kernel/efitools/efitools-native_%.bbappend
@@ -1,1 +1,0 @@
-SRC_URI += "file://0001-lib-console-compatibly-fix-to-upstream-change-of-gnu.patch"

--- a/recipes-kernel/efitools/efitools-native_1.8.1.bb
+++ b/recipes-kernel/efitools/efitools-native_1.8.1.bb
@@ -1,23 +1,12 @@
-SUMMARY = "efitools"
-DESCRIPTION = "EFI tools to generate an deploy platform keys"
-HOMEPAGE = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git/"
-SECTION = "console/tools"
-LICENSE = "GPLv2"
-
-LIC_FILES_CHKSUM = "file://COPYING;md5=e28f66b16cb46be47b20a4cdfe6e99a1"
+require efitools-common.inc
 
 SRC_URI[md5sum] = "5f20ed9cccf786cf6525c54537ae7831"
 SRC_URI[sha256sum] = "d48b66768374ce742971c44e475b7336992b3d0a51407920a2e3876e8d9fc329"
-
-SRC_URI = "https://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git/snapshot/efitools_${PV}.tar.gz"
 
 inherit native
 inherit perlnative
 
 DEPENDS = "gnu-efi-native help2man-native sbsigntool-native libfile-slurp-perl-native"
-
-S = "${WORKDIR}/efitools_${PV}"
-
 
 EFIFILES = "\
 	LockDown.efi \

--- a/recipes-kernel/efitools/efitools_1.9.2.bb
+++ b/recipes-kernel/efitools/efitools_1.9.2.bb
@@ -3,38 +3,21 @@ require efitools-common.inc
 SRC_URI[md5sum] = "f2da7eb801f6965b19d61ca3341f9ecb"
 SRC_URI[sha256sum] = "f4ece634a498bde73dc23d1aab1171a07b64718bd47f167240a7db4049e729b4"
 
-inherit native
-inherit perlnative
+DEPENDS = "gnu-efi openssl"
 
-DEPENDS = "gnu-efi-native help2man-native sbsigntool-native libfile-slurp-perl-native"
-
-EFIFILES = "\
-	LockDown.efi \
-	KeyTool.efi \
-"
+INSANE_SKIP:${PN} = "ldflags"
 
 BINARIES = "\
-	cert-to-efi-sig-list \
-	sig-list-to-certs \
-	sign-efi-sig-list \
-	hash-to-efi-sig-list \
-	cert-to-efi-hash-list \
+	efi-keytool \
+	efi-readvar \
+	efi-updatevar \
 "
-
-LIBRARY_FLAGS = "\
-	-nostdlib -shared -Bsymbolic \
-	${STAGING_LIBDIR}/crt0-efi-${HOST_ARCH}.o \
-	-L ${STAGING_LIBDIR} \
-	-T ${STAGING_LIBDIR}/elf_${HOST_ARCH}_efi.lds \
-"
-
-#tmp/sysroots-components/x86_64/gnu-efi-native/usr/lib/crt0-efi-x86_64.o
 
 INCLUDES = "\
 	-I${S}/include \
 	-I${STAGING_INCDIR} \
 	-I${STAGING_INCDIR}/efi \
-	-I${STAGING_INCDIR}/efi/${HOST_ARCH} \
+	-I${STAGING_INCDIR}/efi/${TARGET_ARCH} \
 	-I${STAGING_INCDIR}/efi/protocol \
 "
 
@@ -46,17 +29,15 @@ EXTRA_OEMAKE = "\
         'CC = ${CC} -L ${STAGING_LIBDIR}' \
         'LD = ${LD}' \
 	'INCDIR = ${INCLUDES}' \
-	'LDFLAGS = ${LIBRARY_FLAGS}' \
 "
 
 do_compile() {
 	oe_runmake ${BINARIES}
-	oe_runmake ${EFIFILES}
 }
 
 do_install () {
 	install -d ${D}${bindir}
-	for bin in ${BINARIES} ${EFIFILES}; do
+	for bin in ${BINARIES}; do
 		install ${S}/${bin} ${D}${bindir}
 	done
 }

--- a/recipes-trustx/installer-keytool/files/install_sbkeys.sh
+++ b/recipes-trustx/installer-keytool/files/install_sbkeys.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+die() {
+	echo "Failed installing secure boot key. Exit."
+	exit 1
+}
+
+mount | grep efivarfs || mount -t efivarfs efivarfs /sys/firmware/efi/efivars
+
+echo "Installing DB.esl ..."
+efi-updatevar -e -f /usr/share/sbkeys/DB.esl db || die
+efi-readvar -v db
+echo "OK"
+
+echo "Installing KEK.esl ..."
+efi-updatevar -e -f /usr/share/sbkeys/KEK.esl KEK || die
+efi-readvar -v KEK
+echo "OK"
+
+echo "Installing PK.auth ..."
+efi-updatevar -f /usr/share/sbkeys/PK.auth PK || die
+efi-readvar -v PK
+echo "OK"
+
+echo "Installed secure boot keys successfully"

--- a/recipes-trustx/installer-keytool/installer-keytool.bb
+++ b/recipes-trustx/installer-keytool/installer-keytool.bb
@@ -1,0 +1,23 @@
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${TOPDIR}/../trustme/build/COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI = "file://install_sbkeys.sh"
+
+TEST_CERT_DIR = "${TOPDIR}/test_certificates"
+SB_KEYS_DIR = "${D}${datadir}/sbkeys"
+
+DEPENDS = "pki-native"
+RDEPENDS:${PN} = "efitools"
+
+do_install() {
+	install -d ${SB_KEYS_DIR}
+	cp --dereference ${TEST_CERT_DIR}/DB.esl ${SB_KEYS_DIR}
+	cp --dereference ${TEST_CERT_DIR}/KEK.esl ${SB_KEYS_DIR}
+	cp --dereference ${TEST_CERT_DIR}/PK.auth ${SB_KEYS_DIR}
+
+	install -d ${D}${bindir}
+	install -m 755 ${WORKDIR}/install_sbkeys.sh ${D}${bindir}
+}
+
+FILES:${PN} += " /usr/*"


### PR DESCRIPTION
This PR makes two contributions:

1. Rework efitools recipes and provide an efitools recipe for the target architecture.
2. Install secure boot keys along with a script 'install_sbkeys.sh' to the trustme-installer that writes the keys to UEFI. The keys are exactly the same as are used in the trustx-keytool image.

Installing the secure boot keys was tested on QEMU with OVMF edk2-stable202008.
TODO: Test on real hardware.