### PR TITLE
Kirkstone build process refactoring

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,40 @@
+pipeline {
+	agent any
+
+	parameters {
+		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of additional pull request branches (e.g. meta-trustx=PR-177,meta-trustx-nxp=PR-13,gyroidos_build=PR-97)')
+	}
+
+	stages {
+		stage('build GyroidOS') {
+			steps {
+				script {
+					REPO_NAME = determineRepoName()
+
+					if (CHANGE_TARGET != null) {
+						// in case this is a PR build
+						// set the BASE_BRANCH to the target
+						// e.g. PR-123 -> kirkstone
+						BASE_BRANCH = CHANGE_TARGET
+					} else {
+						// in case this is a regular build
+						// let the BASE_BRANCH equal this branch
+						// e.g. kirkstone -> kirkstone
+						BASE_BRANCH = BRANCH_NAME
+					}
+				}
+
+				build job: "../gyroidos/${BASE_BRANCH}", wait: true, parameters: [
+					string(name: "PR_BRANCHES", value: "${REPO_NAME}=${BRANCH_NAME},${PR_BRANCHES}")
+				]
+			}
+		}
+	}
+}
+
+// Determine the Repository name from its URL.
+// Avoids hardcoding the name in every Jenkinsfile individually.
+// Source: https://stackoverflow.com/a/45690925
+String determineRepoName() {
+	return scm.getUserRemoteConfigs()[0].getUrl().tokenize('/').last().split("\\.")[0]
+}

--- a/conf/multiconfig/container_qemux86-64.inc
+++ b/conf/multiconfig/container_qemux86-64.inc
@@ -2,7 +2,7 @@ MACHINE = "qemux86-64"
 
 TMPDIR = "${TOPDIR}/tmp_container"
 
-EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+EXTRA_IMAGE_FEATURES:append = " debug-tweaks"
 
 USER_CLASSES ?= "buildstats"
 

--- a/conf/multiconfig/container_qemux86-64.inc
+++ b/conf/multiconfig/container_qemux86-64.inc
@@ -1,0 +1,38 @@
+MACHINE = "qemux86-64"
+
+TMPDIR = "${TOPDIR}/tmp_container"
+
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+
+USER_CLASSES ?= "buildstats"
+
+PATCHRESOLVE = "noop"
+
+PACKAGECONFIG:append:pn-qemu-native = " sdl"
+PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
+
+CONF_VERSION = "2"
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
+PREFERRED_PROVIDER_virtual/kernel:poky-tiny = "linux-dummy"
+PREFERRED_PROVIDER_virtual/kernel:linuxstdbase = "linux-dummy"
+
+DISTRO = "poky"
+#DISTRO_FEATURES:append = " virtualization"
+
+IMAGE_FSTYPES = "cpio.gz ext4"
+INITRAMFS_IMAGE = ""
+
+TRUSTME_HARDWARE = "x86"
+
+PACKAGE_CLASSES = "package_deb"
+
+# Possible provider: cacao-initial-native and jamvm-initial-native
+PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
+
+# Possible provider: cacao-native and jamvm-native
+PREFERRED_PROVIDER_virtual/java-native = "cacao-native"
+
+# Optional since there is only one provider for now
+PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
+#LICENSE_FLAGS_WHITELIST += "oracle_java"

--- a/conf/multiconfig/installer.conf
+++ b/conf/multiconfig/installer.conf
@@ -1,0 +1,23 @@
+EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+USER_CLASSES ?= "buildstats"
+PATCHRESOLVE = "noop"
+
+PACKAGECONFIG:append:pn-qemu-native = " sdl"
+PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
+
+
+CONF_VERSION = "2"
+DISTRO_FEATURES:append = " virtualization"
+MACHINE = "genericx86-64"
+
+DISTRO = "poky-tiny"
+
+
+IMAGE_FSTYPES = "cpio.gz ext4"
+
+TRUSTME_HARDWARE = "x86"
+
+PACKAGE_CLASSES = "package_ipk"
+FETCHCMD_wget = "/usr/bin/env wget -t 2 -T 30 --passive-ftp --no-check-certificate"
+INITRAMFS_IMAGE="trustx-installer-initramfs"
+KERNEL_DEPLOYSUBDIR = "installer-kernel"

--- a/conf/trustx/genericx86-64.inc
+++ b/conf/trustx/genericx86-64.inc
@@ -1,0 +1,27 @@
+MACHINE = "genericx86-64"
+
+INITRAMFS_IMAGE_BUNDLE = "1"
+INITRAMFS_IMAGE = "trustx-cml-initramfs"
+
+IMAGE_FSTYPES = "cpio ext4"
+TRUSTME_FSTYPES = "trustmex86"
+TRUSTME_PARTTABLE_TYPE = "gpt"
+TRUSTME_CONTAINER_ARCH = "qemux86-64"
+
+TRUSTME_HARDWARE = "x86"
+TRUSTME_LOGTTY = "tty11"
+
+PKI_UEFI_KEYS = "y"
+
+PACKAGE_CLASSES = "package_ipk"
+BBMULTICONFIG = "container installer"
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-vanilla"
+PREFERRED_PROVIDER_virtual/kernel:poky-tiny ?= "linux-vanilla"
+
+INITRAMFS_MODULES = ""
+
+INITRAMFS_MAXSIZE = "150000"
+
+PACKAGE_INSTALL:append:pn-trustx-cml-initramfs = "${INITRAMFS_MODULES}"
+PACKAGE_INSTALL:append:pn-trustx-installer-initramfs = "${INITRAMFS_MODULES}"

--- a/images/trustx-cml.bbappend
+++ b/images/trustx-cml.bbappend
@@ -5,11 +5,12 @@ include images/trustx-signing.inc
 deltask do_sign_guestos
 addtask do_sign_guestos after do_uefi_bootpart before do_image_trustmex86
 
-GUESTS_OUT = "${DEPLOY_DIR_IMAGE}/cml_updates"
+GUESTS_OUT = "${B}/cml_updates"
 CLEAN_GUEST_OUT = ""
 OS_NAME = "kernel"
-UPDATE_OUT="${GUESTS_OUT}/${OS_NAME}-${TRUSTME_VERSION}"
-UPDATE_FILES="${UPDATE_OUT} ${UPDATE_OUT}.conf ${UPDATE_OUT}.sig ${UPDATE_OUT}.cert"
+UPDATE_OUT_GENERIC="${GUESTS_OUT}/${OS_NAME}"
+UPDATE_OUT="${UPDATE_OUT_GENERIC}-${TRUSTME_VERSION}"
+UPDATE_FILES="${UPDATE_OUT_GENERIC} ${UPDATE_OUT_GENERIC}.conf ${UPDATE_OUT_GENERIC}.sig ${UPDATE_OUT_GENERIC}.cert"
 
 do_sign_guestos:prepend () {
 	mkdir -p "${UPDATE_OUT}"
@@ -24,4 +25,9 @@ do_sign_guestos:append () {
 		"${OS_NAME}-${TRUSTME_VERSION}.conf" \
 		"${OS_NAME}-${TRUSTME_VERSION}.sig" \
 		"${OS_NAME}-${TRUSTME_VERSION}.cert"
+
+	ln -sf "$(basename ${UPDATE_OUT})" "${UPDATE_OUT_GENERIC}"
+	ln -sf "$(basename ${UPDATE_OUT}.conf)" "${UPDATE_OUT_GENERIC}.conf"
+	ln -sf "$(basename ${UPDATE_OUT}.cert)" "${UPDATE_OUT_GENERIC}.cert"
+	ln -sf "$(basename ${UPDATE_OUT}.sig)" "${UPDATE_OUT_GENERIC}.sig"
 }

--- a/images/trustx-cml.bbappend
+++ b/images/trustx-cml.bbappend
@@ -2,8 +2,11 @@ inherit trustmex86
 
 ##### provide a tarball for cml update
 include images/trustx-signing.inc
+do_sign_guestos[depends] += " \
+    ${TRUSTME_GENERIC_DEPENDS} \
+"
 deltask do_sign_guestos
-addtask do_sign_guestos after do_uefi_bootpart before do_image_trustmex86
+addtask do_sign_guestos after do_image before do_image_trustmex86
 
 GUESTS_OUT = "${B}/cml_updates"
 CLEAN_GUEST_OUT = ""

--- a/recipes-kernel/linux/linux-debian_%.bbappend
+++ b/recipes-kernel/linux/linux-debian_%.bbappend
@@ -9,3 +9,5 @@ SRC_URI += " \
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-debian:${THISDIR}/generic:"
 
 #KBUILD_DEFCONFIG:genericx86-64 := "${THISDIR}/generic/defconfig"
+
+require uefi-sign.inc

--- a/recipes-kernel/linux/linux-vanilla_%.bbappend
+++ b/recipes-kernel/linux/linux-vanilla_%.bbappend
@@ -6,3 +6,5 @@ SRC_URI += " \
 "
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/generic:"
+
+require uefi-sign.inc

--- a/recipes-kernel/linux/uefi-sign.inc
+++ b/recipes-kernel/linux/uefi-sign.inc
@@ -1,0 +1,16 @@
+DEPENDS += "sbsigntool-native"
+
+TEST_CERT_DIR = "${TOPDIR}/test_certificates"
+SECURE_BOOT_SIGNING_KEY = "${TEST_CERT_DIR}/ssig_subca.key"
+SECURE_BOOT_SIGNING_CERT = "${TEST_CERT_DIR}/ssig_subca.cert"
+
+do_deploy:append () {
+	kernelbin="${DEPLOYDIR}/cml-kernel/bzImage-initramfs-${MACHINE}.bin"
+	kernelbin_signed="${kernelbin}.signed"
+	if [ -L "${kernelbin}" ]; then
+		link=`readlink "${kernelbin}"`
+		ln -sf ${link}.signed ${kernelbin}.signed
+	fi
+
+	sbsign --key "${SECURE_BOOT_SIGNING_KEY}" --cert "${SECURE_BOOT_SIGNING_CERT}" --output "${kernelbin_signed}" "${kernelbin}"
+}


### PR DESCRIPTION
This PR makes various changes to the build system:

- Move machine specific config options from gyroidos_build to yocto layer
- Create symlinks to kernel updates to decouple from TRUSTME_VERSION
- Deploy kernel updates through DEPLOYDIR
- Move UEFI signing to kernel recipe: required from the DEPLOY changes