### PR TITLE
recipes-kernel/linux/linux-rolling-stable: use vanilla config

### DIFF
--- a/recipes-kernel/linux/linux-rolling-stable_%.bbappend
+++ b/recipes-kernel/linux/linux-rolling-stable_%.bbappend
@@ -1,0 +1,1 @@
+linux-vanilla_%.bbappend


### PR DESCRIPTION
Added a link for linux-rolling-stable to vanilla version. This enables the same GyroidOS intel specific config as for vanilla kernel recipes to the new linux-rolling-stable recipe.

This depends on gyroidos/meta-trustx#180