### PR TITLE
trustx-installer-initramfs: fix: usermod -P is deprecated.

### DIFF
--- a/images/trustx-installer-initramfs.bb
+++ b/images/trustx-installer-initramfs.bb
@@ -68,4 +68,4 @@ ROOTFS_POSTPROCESS_COMMAND:append = " update_modules_dep; "
 ROOTFS_POSTPROCESS_COMMAND:append = '${@bb.utils.contains_any("EXTRA_IMAGE_FEATURES", [ 'debug-tweaks' ], " update_inittab ; ", "",d)}'
 
 inherit extrausers
-EXTRA_USERS_PARAMS = '${@bb.utils.contains_any("EXTRA_IMAGE_FEATURES", [ 'debug-tweaks' ], "usermod -P root root; ", "",d)}'
+EXTRA_USERS_PARAMS = '${@bb.utils.contains_any("EXTRA_IMAGE_FEATURES", [ 'debug-tweaks' ], "usermod -p '\$1\$1234\$XJI6P4bccABjEC1v6k64V1' root; ", "",d)}'


### PR DESCRIPTION
Usermod provided by Yocto Kirkstone does not offer the -P switch anymore. Switch to "usermod -p" plus hashed password for debug build. See similar change in meta-trustx repo for 'trustx-cml-initramfs'.