### PR TITLE
conf: Removed obsolete machine trustx-corei7-64

### DIFF
--- a/conf/machine/trustx-corei7-64.conf
+++ b/conf/machine/trustx-corei7-64.conf
@@ -1,5 +1,0 @@
-# use core-i7 machine from meta-intel
-require conf/machine/intel-corei7-64.conf
-
-# overwrite serial consols from intel-corei7-64
-SERIAL_CONSOLES = "115200;ttyS0"


### PR DESCRIPTION
Totally removed manchine subdir from this repo since the machine trustx-corei7-64 was the only machine defined in this layer.