### PR TITLE
move kernel.conf from gyroidos_build to meta-trustx-intel

### DIFF
--- a/images/trustx-cml.bbappend
+++ b/images/trustx-cml.bbappend
@@ -34,3 +34,10 @@ do_sign_guestos:append () {
 	ln -sf "$(basename ${UPDATE_OUT}.cert)" "${UPDATE_OUT_GENERIC}.cert"
 	ln -sf "$(basename ${UPDATE_OUT}.sig)" "${UPDATE_OUT_GENERIC}.sig"
 }
+
+OS_CONFIG_IN := "${THISDIR}/${PN}/${OS_NAME}.conf"
+OS_CONFIG = "${WORKDIR}/${OS_NAME}.conf"
+prepare_kernel_conf () {
+    cp "${OS_CONFIG_IN}" "${OS_CONFIG}"
+}
+IMAGE_PREPROCESS_COMMAND:append = " prepare_kernel_conf;"

--- a/images/trustx-cml/kernel.conf
+++ b/images/trustx-cml/kernel.conf
@@ -1,0 +1,24 @@
+name: "kernel"
+hardware: "x86"
+version: 1
+mounts {
+	image_file: "kernel"
+	mount_point: "/boot/EFI/BOOT/BOOTX64.EFI"
+	fs_type: "none"
+	mount_type: FLASH
+}
+mounts {
+	image_file: "modules"
+	mount_point: "/mnt/modules.img"
+	fs_type: "none"
+	mount_type: FLASH
+}
+mounts {
+	image_file: "firmware"
+	mount_point: "/mnt/firmware.img"
+	fs_type: "none"
+	mount_type: FLASH
+}
+description {
+	en: "fake OS for kernel update (x86)"
+}


### PR DESCRIPTION
Changes in meta-trustx allow us to pass a custom path to the
guestos/kernel config to the trustx-signing facility. In order to clean
up gyroidos_build move the kernel update config to this yocto layer.