### PR TITLE
recipes-kernel/linux/uefi-sign: sign kernel if no initrd is appended

### DIFF
--- a/recipes-kernel/linux/uefi-sign.inc
+++ b/recipes-kernel/linux/uefi-sign.inc
@@ -7,6 +7,9 @@ KERNEL_DEPLOYSUBDIR ?= "cml-kernel"
 
 do_deploy:append () {
 	kernelbin="${DEPLOYDIR}/${KERNEL_DEPLOYSUBDIR}/bzImage-initramfs-${MACHINE}.bin"
+	if [ ${INITRAMFS_IMAGE_BUNDLE} != "1" ]; then
+		kernelbin="${DEPLOYDIR}/${KERNEL_DEPLOYSUBDIR}/bzImage-${MACHINE}.bin"
+	fi
 	kernelbin_signed="${kernelbin}.signed"
 	if [ -L "${kernelbin}" ]; then
 		link=`readlink "${kernelbin}"`


### PR DESCRIPTION
If no intiramfs is bundled, e.g., if INITRAMFS_IMAGE_BUNDLE = "0" is set in local.conf or a multiconfig, just sign the binary without initramfs in the image name.