### PR TITLE
recipes-support/sbsigntool: Patch initializing variables

### DIFF
--- a/recipes-support/sbsigntool/sbsigntool-native_git.bb
+++ b/recipes-support/sbsigntool/sbsigntool-native_git.bb
@@ -22,7 +22,8 @@ LIC_FILES_CHKSUM = "file://LICENSE.GPLv3;md5=9eef91148a9b14ec7f9df333daebc746 \
 SRC_URI = "git://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git;protocol=https;name=sbsigntools;branch=master \
            git://github.com/rustyrussell/ccan.git;protocol=https;destsuffix=git/lib/ccan.git;name=ccan;branch=master \
            file://0001-configure-Fixup-build-dependencies-for-cross-compili.patch \
-          "
+           file://0001-fix-uninitialized-variables-reported-by-gcc.patch \
+           "
 
 SRCREV_sbsigntools  ?= "9cfca9fe7aa7a8e29b92fe33ce8433e212c9a8ba"
 SRCREV_ccan         ?= "b1f28e17227f2320d07fe052a8a48942fe17caa5"

--- a/recipes-support/sbsigntool/sbsigntool/0001-fix-uninitialized-variables-reported-by-gcc.patch
+++ b/recipes-support/sbsigntool/sbsigntool/0001-fix-uninitialized-variables-reported-by-gcc.patch
@@ -1,0 +1,24 @@
+From a75c81c67a0d94d706c9ef84d2b510b5afea492f Mon Sep 17 00:00:00 2001
+From: Johannes Wiesboeck <johannes.wiesboeck@aisec.fraunhofer.de>
+Date: Tue, 5 Dec 2023 12:27:08 +0000
+Subject: [PATCH] fix uninitialized variables reported by gcc
+
+---
+ src/fileio.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/fileio.c b/src/fileio.c
+index 032eb1e..9f7e7f3 100644
+--- a/src/fileio.c
++++ b/src/fileio.c
+@@ -142,8 +142,8 @@ static int __fileio_read_file(void *ctx, const char *filename,
+ 		 uint8_t **out_buf, size_t *out_len, int flags)
+ {
+ 	struct stat statbuf;
+-	uint8_t *buf;
+-	size_t len;
++	uint8_t *buf = NULL;
++	size_t len = 0;
+ 	int fd, rc;
+ 
+ 	rc = -1;


### PR DESCRIPTION
Newer gcc versions complain about uninitialized variables in sbsigntool when compiling with asan. Provide a patch fixing the uninitialized variables.