### PR TITLE
images/trustx-cml: integrate device.conf into cml_update tarball

### DIFF
--- a/images/trustx-cml.bbappend
+++ b/images/trustx-cml.bbappend
@@ -20,6 +20,7 @@ do_sign_guestos:prepend () {
 	cp "${DEPLOY_DIR_IMAGE}/cml-kernel/bzImage-initramfs-${MACHINE}.bin.signed" "${UPDATE_OUT}/kernel.img"
 	cp "${DEPLOY_DIR_IMAGE}/trustx-cml-firmware-${MACHINE}.squashfs" "${UPDATE_OUT}/firmware.img"
 	cp "${DEPLOY_DIR_IMAGE}/trustx-cml-modules-${MACHINE}.squashfs" "${UPDATE_OUT}/modules.img"
+	cp "${WORKDIR}/device.conf" "${UPDATE_OUT}/device.img"
 }
 
 do_sign_guestos:append () {

--- a/images/trustx-cml/kernel.conf
+++ b/images/trustx-cml/kernel.conf
@@ -19,6 +19,12 @@ mounts {
 	fs_type: "none"
 	mount_type: FLASH
 }
+mounts {
+	image_file: "device"
+	mount_point: "/data/cml/device.conf"
+	fs_type: "none"
+	mount_type: FLASH
+}
 description {
 	en: "fake OS for kernel update (x86)"
 }


### PR DESCRIPTION
Bundle working devicer.conf to the cml update. E.g., if changes to the underlying system, e.g. audit log storage needs to be changed during updates of the CML.