### PR TITLE
recipes-kernel/linux/linux-rolling-stable: PKCS#11 Secure Boot signing

### DIFF
--- a/recipes-kernel/linux/uefi-sign.inc
+++ b/recipes-kernel/linux/uefi-sign.inc
@@ -1,9 +1,17 @@
 DEPENDS += "sbsigntool-native"
 
+inherit p11-signing
+
 TEST_CERT_DIR = "${TOPDIR}/test_certificates"
-SECURE_BOOT_SIGNING_KEY = "${TEST_CERT_DIR}/ssig_subca.key"
-SECURE_BOOT_SIGNING_CERT = "${TEST_CERT_DIR}/ssig_subca.cert"
+SECURE_BOOT_SIGNING_KEY ?= "${KERNEL_MODULE_SIG_KEY}"
+SECURE_BOOT_SIGNING_CERT ?= "${STAGING_KERNEL_BUILDDIR}/certs/signing_key.x509"
+SBSIGN_CMD = 'sbsign --key "${SECURE_BOOT_SIGNING_KEY}" --cert "${SECURE_BOOT_SIGNING_CERT}.pem" --output "${kernelbin_signed}" "${kernelbin}"'
+SBSIGN_CMD:pkcs11-sign = 'sbsign --engine pkcs11 --key "${SECURE_BOOT_SIGNING_KEY}" --cert "${SECURE_BOOT_SIGNING_CERT}.pem" --output "${kernelbin_signed}" "${kernelbin}"'
 KERNEL_DEPLOYSUBDIR ?= "cml-kernel"
+
+do_deploy:prepend () {
+        openssl x509 -in ${SECURE_BOOT_SIGNING_CERT} -outform PEM -out ${SECURE_BOOT_SIGNING_CERT}.pem
+}
 
 do_deploy:append () {
 	kernelbin="${DEPLOYDIR}/${KERNEL_DEPLOYSUBDIR}/bzImage-initramfs-${MACHINE}.bin"
@@ -16,5 +24,5 @@ do_deploy:append () {
 		ln -sf ${link}.signed ${kernelbin}.signed
 	fi
 
-	sbsign --key "${SECURE_BOOT_SIGNING_KEY}" --cert "${SECURE_BOOT_SIGNING_CERT}" --output "${kernelbin_signed}" "${kernelbin}"
+	${SBSIGN_CMD}
 }


### PR DESCRIPTION
In case SECURE_BOOT_SIGNING_KEY start with 'pkcs11:' override sbsign command to use PKCS#11 token for secure boot signing.